### PR TITLE
Add CommonJS Modules; Closes #14

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -1,4 +1,4 @@
-//var Vector = require('./vector.js');
+var Vector = require('./vector.js');
 
 /**
  * Constucts a new rigid body to include in a simluation system.
@@ -98,4 +98,4 @@ Body.prototype = {
     }
 }
 
-//module.exports = Body;
+module.exports = Body;

--- a/src/body.js
+++ b/src/body.js
@@ -15,7 +15,7 @@ function Body(mass, position, velocity, radius) {
     this.force = new Vector(0,0);
     this.mass = mass;
     this.radius = radius;
-    this.setMassRadius(mass,radius)
+    this.setMassRadius(mass,radius);
     this.position = position || new Vector(0,0);
     this.velocity = velocity || new Vector(0,0);
     this.luminosity = -1;
@@ -96,6 +96,6 @@ Body.prototype = {
     toString: function() {
         return "P: " + this.position.toString() + " V: " + this.velocity.toString() + " M: " + this.mass;
     }
-}
+};
 
 module.exports = Body;

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,5 +1,5 @@
-//var Body = require('./body.js');
-//var Vector = require('./vector.js');
+var Body = require('./body.js');
+var Vector = require('./vector.js');
 
 /**
  * Constucts a new simulator with array of bodies
@@ -291,4 +291,4 @@ Simulator.prototype.printState = function() {
 
 // };
 
-//module.exports = Simulator;
+module.exports = Simulator;

--- a/src/engine.js
+++ b/src/engine.js
@@ -11,7 +11,7 @@ var Vector = require('./vector.js');
 
 function Simulator(bodies) {
 
-    this.bodies = bodies
+    this.bodies = bodies;
 
     this.G = 667.3;                 // Establish gravitational constant
     this.PI2 = Math.PI * 2;         // Establish this.PI2 constant
@@ -40,7 +40,7 @@ function Simulator() {
         new Body(10, new Vector(150,-200), new Vector(0,0), 10),
         new Body(10, new Vector(-100,-100)   , new Vector(0,0), 10),
         new Body(12, new Vector(-150,200) , new Vector(0,0), 10)
-    ]
+    ];
 
     this.G = 667.3;                 // Establish gravitational constant
     this.PI2 = Math.PI * 2;         // Establish this.PI2 constant
@@ -68,7 +68,7 @@ Simulator.prototype.update = function(dT) {
     for (var a = 0; a < this.bodies.length-1; a++) {
 
         // If not null
-        if (this.bodies[a] != null) {
+        if (this.bodies[a] !== null) {
             var bodyA = this.bodies[a];
 
             // For each body below bodyA
@@ -82,7 +82,7 @@ Simulator.prototype.update = function(dT) {
                 var bodyB = this.bodies[b];
 
                 // If not null
-                 if (this.bodies[b] != null) {
+                 if (this.bodies[b] !== null) {
 
                     var r = bodyA.position.distanceTo(bodyB.position);
 
@@ -147,7 +147,7 @@ Simulator.prototype.update = function(dT) {
 
     // Now that all the forces have been calculated, we can apply them to the bodies to update their velocities and positions.
     for (var c = 0; c < this.bodies.length; c++) {
-        if (this.bodies[c] != null) {
+        if (this.bodies[c] !== null) {
             //this.bodies[c].applyForce(this.deltaTime / 1000); LEGACY 
             this.bodies[c].applyForce(dT);
             this.simulationTime += dT;
@@ -166,7 +166,7 @@ Simulator.prototype.update = function(dT) {
  */
 Simulator.prototype.resume = function () {
     this.resumed = true;
-}
+};
 
 // Simulator.prototype.initialize = function() {
 //     var initBodies = new Array(this.bodies.length);
@@ -261,7 +261,7 @@ Simulator.prototype.printState = function() {
     console.log("Time Passed: " + ((this.timer.getTime() - this.startTime)/1000.0));
     console.log("Simulation Time: " + this.simulationTime);
     for(var i = 0; i < this.bodies.length; i++) {
-        if (this.bodies[i] != null) {
+        if (this.bodies[i] !== null) {
             console.log("ID: " + i + "\t " + this.bodies[i].toString());
         }
         else {

--- a/src/vector.js
+++ b/src/vector.js
@@ -57,4 +57,4 @@ Vector.prototype = {
     }
 }
 
-//module.exports = Vector;
+module.exports = Vector;

--- a/src/vector.js
+++ b/src/vector.js
@@ -55,6 +55,6 @@ Vector.prototype = {
     toString: function() {
         return "(" + this.x + "," + this.y + ")";
     }
-}
+};
 
 module.exports = Vector;


### PR DESCRIPTION
## Problem

The engine cannot be imported by other libraries because it lacks module definitions.

## Solution

Expose the simulator implementation as CommonJS modules allowing the bridge library to import engine as a dependency and include it in the application
