### PR TITLE
Use Correct Parameters When Parsing; Closes #27

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -61,22 +61,23 @@ function Simulator() {
 
 }
 
-var parseBody = function (body) {
-  if (body instanceof Body) return body;
-
-  var position = new Vector(body.position.x, body.position.y);
-  var velocity = new Vector(body.velocity.x, body.velocity.y);
-  return new Body(body.radius, position, velocity, null);
-};
-
 /**
  * Resests the current simulation with a new set of bodies.
  *
  * @param {array} bodies - A collection of body objects
  */
 Simulator.prototype.reset = function(bodies) {
+
   bodies = bodies || [];
-  this.bodies = bodies.map(parseBody);
+
+  this.bodies = bodies.map(function(body) {
+    if (body instanceof Body) return body;
+
+    var position = new Vector(body.position.x, body.position.y);
+    var velocity = new Vector(body.velocity.x, body.velocity.y);
+
+    return new Body(body.mass, position, velocity, body.radius);
+  });
 };
 
 /**

--- a/test/engine.js
+++ b/test/engine.js
@@ -2,6 +2,7 @@ var _          = require('lodash');
 var Body       = require('../src/body.js');
 var expect     = require('chai').expect;
 var Simulation = require('../src/engine.js');
+var Vector     = require('../src/vector.js');
 
 describe('Simulation', function() {
   it('should reset with given bodies', function() {
@@ -10,13 +11,23 @@ describe('Simulation', function() {
 
     var body = {
       mass: 1,
-      position: {x: 0, y: 0},
+      position: {x: 1, y: 2},
       radius: 1,
-      velocity: {x: 0, y: 0}
+      velocity: {x: 3, y: 4}
     };
 
     simulation.reset([body]);
     expect(simulation.bodies).not.to.be.empty;
-    expect(simulation.bodies[0] instanceof Body).to.be.true;
+
+    var parsedBody = simulation.bodies[0];
+    console.log(parsedBody.position.prototype);
+    expect(parsedBody instanceof Body).to.be.true;
+    expect(parsedBody.mass).to.equal(body.mass);
+    expect(parsedBody.radius).to.equal(body.radius);
+    expect(parsedBody.position.x).to.equal(1);
+    expect(parsedBody.position.y).to.equal(2);
+    expect(parsedBody.velocity.x).to.equal(3);
+    expect(parsedBody.velocity.y).to.equal(4);
+    expect(parsedBody.density).to.be.a('number');
   });
 });


### PR DESCRIPTION
Problem
=======

When the engine is reset it parses a collection of body like objects. It is currently using the wrong order when standing up parameters.

Solution
========

Use the correct order.

Tests
=====

Expanded the unit tests to assert values align appropriately.

Howto Test
==========

- [ ] Tests Pass

/cc @aaroncameron21