### PR TITLE
Parse Luminosity of Bodies; Closes #32

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -11,9 +11,9 @@ var Vector = require('./vector.js');
  * @param {int}  density    - The initial unit density of the body
  * @param {int}  luminosity - The initial unit luminosity of the body
  */
-function Body(mass, position, velocity, radius) {
+function Body(mass, position, velocity, radius, luminosity) {
     this.force = new Vector(0,0);
-    if (radius == null) {
+    if (radius === null) {
         this.density  = 0.002;
         this.setMass(mass);
     }
@@ -22,7 +22,7 @@ function Body(mass, position, velocity, radius) {
     }
     this.position = position || new Vector(0,0);
     this.velocity = velocity || new Vector(0,0);
-    this.luminosity = -1;
+    this.luminosity = luminosity || 0;
     this.exists = true;
 }
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -76,7 +76,7 @@ Simulator.prototype.reset = function(bodies) {
     var position = new Vector(body.position.x, body.position.y);
     var velocity = new Vector(body.velocity.x, body.velocity.y);
 
-    return new Body(body.mass, position, velocity, body.radius);
+    return new Body(body.mass, position, velocity, body.radius, body.luminosity);
   });
 };
 

--- a/test/engine.js
+++ b/test/engine.js
@@ -13,7 +13,8 @@ describe('Simulation', function() {
       mass: 1,
       position: {x: 1, y: 2},
       radius: 1,
-      velocity: {x: 3, y: 4}
+      velocity: {x: 3, y: 4},
+      luminosity: 1234
     };
 
     simulation.reset([body]);
@@ -29,5 +30,6 @@ describe('Simulation', function() {
     expect(parsedBody.velocity.x).to.equal(3);
     expect(parsedBody.velocity.y).to.equal(4);
     expect(parsedBody.density).to.be.a('number');
+    expect(parsedBody.luminosity).to.equal(1234);
   });
 });


### PR DESCRIPTION
Problem
=======

When the simulator receives a set of new bodies it does not parse luminosity.
This breaks habitable zones.

Solution
========

Parse the luminosity of any passed bodies.

Howto Test
==========

- [ ] Updated tests pass