### PR TITLE
Fixed issue with assigning IDs; Closes #49

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -71,17 +71,17 @@ Simulator.prototype.reset = function(bodies) {
  */
 
 Simulator.prototype.assignIDs = function() {
-    this.idCounter = 0;
+    var tempID = 0;
     this.bodies.forEach(function(body) { 
-        body.id = this.idCounter;
-        this.idCounter += 1;
+        body.id = tempID;
+        tempID += 1;
     });
+    this.idCounter = tempID;
 };
 
 /**
- * Adds a body given an x and y coordinate. Other attributes are generated.
- * @param {Number}  x - x position coordinate
- * @param {Number}  y - y position coordinate
+ * Adds a body given an Object with any attributes, the rest will be generated
+ * @param {Object}  body - Body or Body-like object with any combination of attributes
  */
 
 Simulator.prototype.addBody = function(body) {
@@ -101,6 +101,7 @@ Simulator.prototype.addBody = function(body) {
         body.luminosity
     ); 
     newBody.id = this.idCounter;
+    // console.log(newBody.id);
     this.idCounter += 1;
     this.bodies.push(newBody); 
 };

--- a/test/engine.js
+++ b/test/engine.js
@@ -557,6 +557,17 @@ describe('Simulation', function() {
     });
     
     describe('assignIDs', function() {
+        
+        it('should end with all bodies having number IDs', function() {
+            var simulation = new Simulation();
+            simulation.bodies = [new Body(),new Body(),new Body(),new Body(),new Body(),new Body()];
+            simulation.assignIDs();
+            
+            simulation.bodies.forEach( function(bodyA) {
+                expect(bodyA.id).not.to.equal(NaN);
+            });
+        });
+        
         it('should end with all bodies having unique IDs', function() {
             var simulation = new Simulation();
             simulation.bodies = [new Body(),new Body(),new Body(),new Body(),new Body(),new Body()];


### PR DESCRIPTION
There was a scope issue where ‘this.idCounter’ was not visible within a
for loop, so it was assigning undefined values to the body’s ID. Fixed
this and added a test to prevent this kind of error in the future.