### PR TITLE
Handle Non Numeric Types in Update

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -64,7 +64,10 @@ Body.prototype = {
         
         this.luminosity = parseFloat(body.luminosity) || this.luminosity;
         
-        this.setMassRadius(body.mass || this.mass, body.radius || this.radius);
+        var mass = parseFloat(body.mass);
+        var radius = parseFloat(body.radius);
+        
+        this.setMassRadius(mass === 0 ? this.mass : mass || this.mass , radius === 0 ? this.radius : radius || this.radius);
         
         this.color = body.color || this.color;
     },

--- a/src/body.js
+++ b/src/body.js
@@ -47,16 +47,22 @@ Body.prototype = {
      */
     
     update: function(body) {
+        
         if (body.position) {
-            this.position.x = body.position.x || this.position.x;
-            this.position.y = body.position.y || this.position.y;
+          var x = parseFloat(body.position.x);
+          var y = parseFloat(body.position.y);
+          this.position.x = x === 0 ? 0 : x || this.position.x;
+          this.position.y = y === 0 ? 0 : y || this.position.y;
         }
+
         if (body.velocity) {
-            this.velocity.x = body.velocity.x || this.velocity.x;
-            this.velocity.y = body.velocity.y || this.velocity.y;
+          var x = parseFloat(body.velocity.x);
+          var y = parseFloat(body.velocity.y);
+          this.velocity.x = x === 0 ? 0 : x || this.velocity.x;
+          this.velocity.y = y === 0 ? 0 : y || this.velocity.y;
         }
         
-        this.luminosity = body.luminosity || this.luminosity;
+        this.luminosity = parseFloat(body.luminosity) || this.luminosity;
         
         this.setMassRadius(body.mass || this.mass, body.radius || this.radius);
         

--- a/test/body.js
+++ b/test/body.js
@@ -102,6 +102,35 @@ describe('Body', function() {
             expect(b.radius).to.equal(1);
             expect(b.luminosity).to.equal(1);
         });
+
+        it('should parse position as a float', function() {
+          var position = {position: {x: "23.2"}};
+
+          b.update(position);
+          expect(b.position.x).to.equal(23.2);
+        });
+
+        it('should parse velocity as a string', function() {
+          var velocity = {velocity: {x: "-100.232"}};
+
+          b.update(velocity);
+          expect(b.velocity.x).to.equal(-100.232);
+        });
+
+        it('retain previous value when given value is not numeric', function() {
+          var velocity = {velocity: {x: "not a number"}};
+
+          b.update(velocity);
+          expect(b.velocity.x).to.equal(1);
+        });
+
+        it('should allow you to zero a value', function() {
+            var velocity = {velocity: {x: "0", y: "0"}};
+
+            b.update(velocity);
+            expect(b.velocity.x).to.equal(0);
+            expect(b.velocity.y).to.equal(0);
+        });
         
         it('should be able to update only y position attribute', function() {
             modifier = {position: {y: 2}};


### PR DESCRIPTION
Problem
-------

It is possible to give the simulator an update object that has non numeric
values for numeric types. This introduces chaos when the simulator ends up with
a NaN value.

Solution
--------

Attempt to parse the given value and use the previous vaule if a NaN value is
returned.

Howto Test
----------

- Unit tests updated

Resources
---------

- Closes #76