### PR TITLE
Assigns same bodies to new tracker on local reset

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -84,6 +84,7 @@ Body.prototype = {
         this.setMassRadius(mass === 0 ? this.mass : mass || this.mass , radius === 0 ? this.radius : radius || this.radius);
 
         this.color = body.color || this.color;
+        this.name  = body.name  || this.name;
         this.hideHabitable = (body.hideHabitable ? true : false); // false if undef
     },
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -68,10 +68,31 @@ Simulator.prototype.isEditable = function() {
 
 Simulator.prototype.resetLocal = function() {
     
+    var tID = this.orbitTracker.targetBody.name;
+    var cID = this.orbitTracker.centerBody.name;
+    this.orbitTracker = new OrbitTracker();
+    
+    
     
     this.bodies = this.resetState.bodies.map(function(body) {
         return body.copy();
     });
+    
+    this.orbitTracker.setCenterBody(
+        this.bodies.filter(
+            function(body) {
+                return (body.name === cID);
+            }
+        )[0] || null
+    );
+    
+    this.orbitTracker.setTargetBody(
+        this.bodies.filter(
+            function(body) {
+                return (body.name === tID);
+            }
+        )[0] || null
+    );
     
     this.resetValues();
     

--- a/src/engine.js
+++ b/src/engine.js
@@ -68,8 +68,9 @@ Simulator.prototype.isEditable = function() {
 
 Simulator.prototype.resetLocal = function() {
     
-    var tID = this.orbitTracker.targetBody.name;
-    var cID = this.orbitTracker.centerBody.name;
+    var targetName = (this.orbitTracker.targetBody || {name: null}).name;
+    var centerName = (this.orbitTracker.centerBody || {name: null}).name;
+    var trackerState = this.orbitTracker.running;
     this.orbitTracker = new OrbitTracker();
     
     
@@ -81,7 +82,7 @@ Simulator.prototype.resetLocal = function() {
     this.orbitTracker.setCenterBody(
         this.bodies.filter(
             function(body) {
-                return (body.name === cID);
+                return (body.name === centerName);
             }
         )[0] || null
     );
@@ -89,10 +90,12 @@ Simulator.prototype.resetLocal = function() {
     this.orbitTracker.setTargetBody(
         this.bodies.filter(
             function(body) {
-                return (body.name === tID);
+                return (body.name === targetName);
             }
         )[0] || null
     );
+    
+    //this.orbitTracker.setState(trackerState,this.simulationTime);
     
     this.resetValues();
     

--- a/test/engine.js
+++ b/test/engine.js
@@ -325,6 +325,33 @@ describe('resetLocal', function() {
         expect(simulation.bodies[1].position.x).to.equal(1000000000);
 
     });
+    
+    it('should set orbit tracker selections to corresponding duplicate bodies', function() {
+        var simulation = new Simulation();
+        expect(simulation.bodies).to.be.empty;
+        
+        simulation.addBody({});
+        simulation.addBody({position: {x: 1000000000}});
+        
+        var cBody = simulation.bodies[0];
+        var tBody = simulation.bodies[1];
+        simulation.updateBody(cBody.id,{name: "Center"});
+        simulation.updateBody(tBody.id,{name: "Target"});
+        simulation.orbitTracker.setCenterBody(cBody);
+        simulation.orbitTracker.setTargetBody(tBody);
+        console.log(simulation.orbitTracker.centerBody);
+        
+        simulation.addNote({});
+        simulation.update(40000);
+        simulation.resetLocal();
+        console.log(simulation.orbitTracker.centerBody);
+        
+        cBody.name = "Old Center";
+        tBody.name = "Old Target";
+        expect(simulation.orbitTracker.centerBody.name).to.equal("Center");
+        expect(simulation.orbitTracker.targetBody.name).to.equal("Target");
+
+    });
   });
   
   describe('resetValues', function() {


### PR DESCRIPTION
This allows the orbit tracker to maintain the same previously selected bodies after a local reset.